### PR TITLE
Removed Unused Dependency and added a dependency validator #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,43 @@ This repository makes use of the following pub packages:
 | [Hive](https://pub.dev/packages/hive)                               | ^2.2.3  | Platform independent storage.      |
 | [Url Launcher](https://pub.dev/packages/url_launcher)               | ^6.1.7  | Open urls in Browser               |
 | [Ionicons](https://pub.dev/packages/ionicons)                       | ^0.2.2  | Modern icon library                |
+| [Dependency Validator](https://pub.dev/packages/dependency_validator) | ^3.2.3  | Validate and check for outdated packages   |
 
 > \* Recommended to keep regardless of your project
 
 ## Using this package as a starting point
 
 After following the installation steps you can customize your project. 
+
+### Checking Dependencies
+
+To ensure that your project dependencies are up-to-date and don't have any security vulnerabilities, you can use the `dependency_validator` package. Follow these steps:
+
+1. Add `dependency_validator` to your `dev_dependencies` in [pubspec.yaml](./pubspec.yaml):
+
+    ```yaml
+    dev_dependencies:
+      dependency_validator: ^3.2.3
+    ```
+
+2. Run the following command in your terminal to check for outdated and vulnerable dependencies:
+
+    ```bash
+    dart pub run dependency_validator
+    ```
+
+    This command will provide information about any outdated or vulnerable packages in your project.
+
+3. Review the output to identify any dependencies that need updating. The report will include information about the current and latest versions of each package.
+
+4. Update your `pubspec.yaml` file with the latest versions of the outdated packages.
+
+5. Run `dart pub get` to fetch the updated dependencies.
+
+6. Re-run the `dart pub run dependency_validator` command to ensure all dependencies are now up-to-date.
+
+
+
 
 The screens and widgets that
 are inside the project can be easily replaced or removed. They are supposed to give the user a basic

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,13 +5,11 @@
 import FlutterMacOS
 import Foundation
 
-import connectivity_plus
-import path_provider_macos
+import path_provider_foundation
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,42 +36,24 @@ dependencies:
   ionicons: ^0.2.2
   cupertino_icons: ^1.0.2
   flutter_riverpod: ^2.3.6
-  riverpod: ^2.3.6
-  hooks_riverpod: ^2.3.6
-  flutter_hooks: ^0.20.3
-  dio: ^5.2.1+1
-  equatable: ^2.0.5
   freezed_annotation: ^2.2.0
   riverpod_annotation: ^2.1.1
   hive: ^2.2.3
-  retrofit: ^4.0.1
-  logger: ^1.4.0
   injectable: ^2.1.2
   get_it: ^7.6.0
   hive_flutter: ^1.1.0
   get_storage: ^2.1.1
   gap: ^3.0.1
-  network_logger: ^1.0.4
-  json_annotation: ^4.8.1
   go_router: ^12.0.0
-  fpdart: ^1.1.0
-  connectivity_plus: ^5.0.1
   responsive_builder: ^0.7.0
   flex_color_scheme: ^7.1.2
-  json_editor: ^0.0.8
-  liquid_pull_to_refresh: ^3.0.1
-  change_app_package_name: ^1.1.0
   url_launcher: ^6.1.11
-  intl: ^0.18.0
-  flutter_html: ^3.0.0-beta.2
-  swipeable_tile: ^2.0.0+3
-  flutter_swipe_action_cell: ^3.1.2
   stack_trace: ^1.11.0
-  animated_notch_bottom_bar: ^1.0.0
   water_drop_nav_bar: ^2.2.0+5
-
+  dart_depcheck: ^0.0.1-dev.6+1
 
 dev_dependencies:
+  dependency_validator: ^3.1.0
   flutter_test:
     sdk: flutter
 
@@ -81,15 +63,6 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^3.0.1
-  # The "build_runner" package provides a way to generate files using Dart code
-  build_runner: ^2.4.5
-  json_serializable: ^6.7.0
-  riverpod_generator: ^2.2.3
-  riverpod_lint: ^2.3.2
-  retrofit_generator: ^8.0.3
-  injectable_generator: ^2.1.6
-  hive_generator: ^2.0.0
-  freezed: ^2.3.5
 
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,9 +51,17 @@ dependencies:
   stack_trace: ^1.11.0
   water_drop_nav_bar: ^2.2.0+5
   dart_depcheck: ^0.0.1-dev.6+1
+  riverpod: ^2.3.6
+  retrofit: ^4.0.1
+  hooks_riverpod: ^2.3.6
+  flutter_hooks: ^0.20.3
+  dio: ^5.2.1+1
+  fpdart: ^1.1.0
+  change_app_package_name: ^1.1.0
 
 dev_dependencies:
   dependency_validator: ^3.1.0
+  build_runner: ^2.4.5
   flutter_test:
     sdk: flutter
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  connectivity_plus
   url_launcher_windows
 )
 


### PR DESCRIPTION
Hey there, I've removed the unused dependency from the project, but I have left few of them which I thought you may need to use them later in the project (cupertino_icons, flutter_test, flutter_lints). Also as mentioned by you I have added a package for managing the dependency  named "dependency_validator", but I want to suggest a differnet package to do the same, this package is named as "dart_depcheck", Here is the official documentation https://pub.dev/packages/dart_depcheck, you just need to run dart_depcheck command in the root directory of the project and it will list out all the unused dependency like this                       
![image](https://github.com/Erengun/Flutter-Riverpod-2.0-Template/assets/109286547/7614e51a-133a-4769-ba77-dc0d193ed72a)
but if you dont prefer this, you may simply remove this, it will have no effect on the project 
I hope you will like my contribution :)