### PR TITLE
chore: Remove the temporary analyzer fix

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,13 +20,6 @@ jobs:
         with:
           channel: stable
       - run: flutter --version
-
-      - name: Temporary fix analyzer
-        run: |
-          echo "Temporary fix analyzer see https://github.com/dart-lang/sdk/issues/60784"
-          flutter pub add override:analyzer:7.3.0
-          flutter pub add override:analyzer_plugin:0.12.0
-          flutter pub add override:custom_lint_visitor:1.0.0+7.1.0
       
       - name: Install dependencies
         run: flutter pub get


### PR DESCRIPTION
This pull request removes a temporary workaround for a Dart analyzer issue from the `lint.yaml` GitHub Actions workflow. The workflow is now streamlined and no longer includes steps to override specific analyzer-related packages.

* Removal of temporary analyzer fix: Deleted steps that added overrides for `analyzer`, `analyzer_plugin`, and `custom_lint_visitor` as a workaround for a Dart SDK issue.